### PR TITLE
🧪 test: Update pytest configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["ChaserZ98 <feiyuzheng98@gmail.com>"]
 readme = "README.md"
-packages = [{include = "chaserland_common", from = "src"}]
+packages = [{ include = "chaserland_common", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.12"
@@ -13,6 +13,10 @@ python = "^3.12"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"
 pytest-cov = "^5.0.0"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = ["--cov=chaserland_common", "--cov-report=html"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This pull request updates the pytest configuration in the pyproject.toml file. Specifically, it adds the `minversion` and `addopts` options to the `[tool.pytest.ini_options]` section. The `minversion` option specifies the minimum version of pytest required, and the `addopts` option specifies additional command-line options to be passed to pytest when running tests.