### PR TITLE
🐎 ci: Add test label to changelog configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,6 +23,9 @@ changelog:
     - title: Dependencies
       labels:
         - dependencies
+    - title: Tests
+      labels:
+        - test
     - title: CI/CD
       labels:
         - CI


### PR DESCRIPTION
This pull request adds the "test" label to the changelog configuration. This label will be used to categorize pull requests related to testing.